### PR TITLE
Chore: Update copyright in license. 

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Passcodes
+Copyright (c) 2024 Jeel Dobariya
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The one that generated by GitHub, when repository is created was kind of mis-align with my original intention of put the copyright of the repository by myself.. 

I have just notice it so i am change to make align with my intention, the impact of this change has every less as repository is just created recently... 

Sorry this time, but now I will try my best to put extra attention from next time...


PS: I am still learning about copyright in open source so this type inconvenience exists... I still consider myself to be new to open source world.